### PR TITLE
[Images] Replace example domain with generic example

### DIFF
--- a/products/images/src/content/cloudflare-images/serve-images/index.md
+++ b/products/images/src/content/cloudflare-images/serve-images/index.md
@@ -40,18 +40,18 @@ When a client requests an image, Cloudflare Images will pick the optimal format 
 Image delivery is supported from all customer domains under the same Cloudflare account. To serve images through custom domains, an image URL should be adjusted to the following format:
 
 ```txt
-https://somecustomdomain.com/cdn-cgi/imagedelivery/:images_account_hash/:image_id/:variant_name
+https://example.com/cdn-cgi/imagedelivery/:images_account_hash/:image_id/:variant_name
 ```
 
 Example with a custom domain:
 
 ```txt
-https://somecustomdomain.com/cdn-cgi/imagedelivery/ZWd9g1K7eljCn_KDTu_MWA/083eb7b2-5392-4565-b69e-aff66acddd00/public
+https://example.com/cdn-cgi/imagedelivery/ZWd9g1K7eljCn_KDTu_MWA/083eb7b2-5392-4565-b69e-aff66acddd00/public
 ```
 
 In this example, `:images_account_hash`, `:image_id` and `:variant_name` are the same, but the hostname and prefix path is different: 
 
-- `somecustomdomain.com`: Cloudflare proxied domain under the same account as the Cloudflare Images.
+- `example.com`: Cloudflare proxied domain under the same account as the Cloudflare Images.
 - `/cdn-cgi/imagedelivery`: Path to trigger cdn-cgi image proxy.
 - `ZWd9g1K7eljCn_KDTu_MWA`: The Images account hash.
 - `083eb7b2-5392-4565-b69e-aff66acddd00`: The image id.


### PR DESCRIPTION
I for one, LOVE trying to buy domains I see on movies/tvshows - not that I've been successful so far, but I saw this one was used in your docs and it happens to be available.

I wouldn't like to copy that URL and be served something nasty - so I figure best practice would be to replace it with the example.com one.

Thanks for great documentation!